### PR TITLE
Update deps and retest quickstart flow

### DIFF
--- a/app/routers/airline.py
+++ b/app/routers/airline.py
@@ -95,7 +95,7 @@ def get_airlines_list(
         airlines = [r for r in result]
         return airlines
     except Exception as e:
-        return f"Unexpected error: {e}", 500
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
 
 
 @router.get(
@@ -153,7 +153,7 @@ def get_airlines_to_airport(
         airlines = [r for r in result]
         return airlines
     except Exception as e:
-        return HTTPException(status_code=500, detail=f"Unexpected error: {e}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
 
 
 @router.get(

--- a/app/routers/airline.py
+++ b/app/routers/airline.py
@@ -1,5 +1,5 @@
 from typing import Union
-from typing_extensions import Annotated
+from typing import Annotated
 
 from couchbase.exceptions import DocumentExistsException, DocumentNotFoundException
 from app.db import get_db

--- a/app/routers/airport.py
+++ b/app/routers/airport.py
@@ -1,5 +1,5 @@
 from typing import Union
-from typing_extensions import Annotated
+from typing import Annotated
 
 from couchbase.exceptions import DocumentExistsException, DocumentNotFoundException
 from app.db import get_db as CouchbaseClient

--- a/app/routers/airport.py
+++ b/app/routers/airport.py
@@ -114,7 +114,7 @@ def get_airports_list(
         airports = [r for r in result]
         return airports
     except Exception as e:
-        return f"Unexpected error: {e}", 500
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
 
 
 class DestinationAirport(BaseModel):
@@ -174,7 +174,7 @@ def get_airport_direct_connections(
         airports = [r for r in result]
         return airports
     except Exception as e:
-        return HTTPException(status_code=500, detail=f"Unexpected error: {e}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
 
 
 @router.get(

--- a/app/routers/hotel.py
+++ b/app/routers/hotel.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from typing_extensions import Annotated
+from typing import Annotated
 
 from app.db import get_db as CouchbaseClient
 from fastapi import APIRouter, Depends, HTTPException, Query

--- a/app/routers/route.py
+++ b/app/routers/route.py
@@ -1,5 +1,5 @@
 from typing import Union
-from typing_extensions import Annotated
+from typing import Annotated
 
 from couchbase.exceptions import DocumentExistsException, DocumentNotFoundException
 from app.db import get_db as CouchbaseClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ pydantic==2.13.3
 pydantic-settings==2.14.0
 pytest==9.0.3
 python-dotenv==1.2.2
-typing_extensions==4.15.0
 uvicorn==0.46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ couchbase==4.6.1
 fastapi==0.136.1
 httpx==0.28.1
 pydantic==2.13.3
-pydantic_settings==2.14.0
+pydantic-settings==2.14.0
 pytest==9.0.3
 python-dotenv==1.2.2
+typing_extensions==4.15.0
 uvicorn==0.46.0


### PR DESCRIPTION
## Summary
- fix FastAPI error handling in the airline/airport query endpoints so unexpected query failures return HTTP 500 instead of 200s after the FastAPI upgrade
- keep `Annotated` imports on the standard-library `typing` module and avoid a now-unnecessary direct `typing_extensions` requirement
- keep the canonical `pydantic-settings` package spelling in `requirements.txt`

## Verification
- `python -m pytest` ✅ (`47 passed` on Python 3.12.13 during the 2026-05-04 follow-up)
- `python -m compileall app` ✅
- `fastapi.testclient.TestClient(app).get("/docs")` ✅ (`200`)
- branch inspection confirms `requirements.txt` no longer includes `typing_extensions`, and app code imports `Annotated` from `typing`

## Notes
- The earlier review concern about needing a direct `typing_extensions` dependency is no longer applicable on the current branch head (`4256260`), because the branch now uses the standard-library `Annotated` import instead.
- Follow-up evidence for this sweep lives under `tutorial-maintenance/runs/weekly-manifest-maintenance-sweep/2026-05-05T0000Z/subagents/python-pr-followup/pr227/`.
