### PR TITLE
Fix hotel OpenAPI source links

### DIFF
--- a/app/routers/hotel.py
+++ b/app/routers/hotel.py
@@ -40,7 +40,7 @@ class Hotel(BaseModel):
 @router.get(
     "/autocomplete",
     response_model=List[HotelName],
-    description="Search for hotels based on their name. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to search for a specific name using the fts index.\n\n Code: [`api/hotel.py`](https://github.com/couchbase-examples/python-quickstart/blob/main/src/api/hotel.py) \n Method: `get`",
+    description="Search for hotels based on their name. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to search for a specific name using the fts index.\n\n Code: [`routers/hotel.py`](https://github.com/couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py) \n\n Method: `hotel_autocomplete`",
     responses={
         200: {
             "description": "List of Hotel Names",
@@ -72,7 +72,7 @@ def hotel_autocomplete(
 @router.post(
     "/filter",
     response_model=List[Hotel],
-    description="Filter hotels using various filters such as name, title, description, country, state and city. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to filter documents using the fts index.\n\n Code: [`api/hotel.py`](https://github.com/couchbase-examples/python-quickstart/blob/main/src/api/hotel.py) \n Method: `post`",
+    description="Filter hotels using various filters such as name, title, description, country, state and city. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to filter documents using the fts index.\n\n Code: [`routers/hotel.py`](https://github.com/couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py) \n\n Method: `hotel_filter`",
     responses={
         200: {
             "description": "List of Hotel",

--- a/app/routers/hotel.py
+++ b/app/routers/hotel.py
@@ -40,7 +40,7 @@ class Hotel(BaseModel):
 @router.get(
     "/autocomplete",
     response_model=List[HotelName],
-    description="Search for hotels based on their name. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to search for a specific name using the fts index.\n\n Code: [`routers/hotel.py`](https://github.com/couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py) \n\n Method: `hotel_autocomplete`",
+    description="Search for hotels based on their name. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to search for a specific name using the fts index.\n\n Code: [`app/routers/hotel.py`](https://github.com/couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py) \n\n Method: `hotel_autocomplete`",
     responses={
         200: {
             "description": "List of Hotel Names",
@@ -72,7 +72,7 @@ def hotel_autocomplete(
 @router.post(
     "/filter",
     response_model=List[Hotel],
-    description="Filter hotels using various filters such as name, title, description, country, state and city. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to filter documents using the fts index.\n\n Code: [`routers/hotel.py`](https://github.com/couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py) \n\n Method: `hotel_filter`",
+    description="Filter hotels using various filters such as name, title, description, country, state and city. \n\n This provides an example of using [Search operations](https://docs.couchbase.com/python-sdk/current/howtos/full-text-searching-with-sdk.html#search-queries) in Couchbase to filter documents using the fts index.\n\n Code: [`app/routers/hotel.py`](https://github.com/couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py) \n\n Method: `hotel_filter`",
     responses={
         200: {
             "description": "List of Hotel",


### PR DESCRIPTION
## Summary
- re-ran the maintenance workflow from current `origin/main` on a fresh `deps/update-2026-04-29` branch
- confirmed the pinned requirements are already current (`pip list --outdated --format=json` returned `[]`) and the app/test flow is healthy on main
- fixed the hotel OpenAPI descriptions so they point to the correct FastAPI repo/path and actual handler names

## Verification
- `uv venv --seed --python /usr/bin/python3.14 .venv`
- `python -m pip install -r requirements.txt`
- `python -m pip list --outdated --format=json` → `[]`
- `python -m pytest` → `47 passed`
- `uvicorn app.main:app --host 127.0.0.1 --port 8000`
- `curl -i http://127.0.0.1:8000/` → `307` redirect to `/docs`
- `curl -s "http://127.0.0.1:8000/api/v1/airport/list?country=France&limit=2"`
- `curl -s "http://127.0.0.1:8000/api/v1/hotel/autocomplete?name=Seal"`
- `curl -s -X POST "http://127.0.0.1:8000/api/v1/hotel/filter?limit=2" -H "Content-Type: application/json" -d {country:United States}`
- live airport CRUD walkthrough against a temporary document (create/read/update/delete) succeeded
- post-fix `python -m pytest` re-run → `47 passed`

## Evidence
- Current main was already healthy: tests passed and no pinned dependency updates were available.
- The fixable drift I found was in the generated OpenAPI docs for the hotel endpoints:
  - `/api/v1/hotel/autocomplete`
  - `/api/v1/hotel/filter`
- Before this change, both descriptions linked to `couchbase-examples/python-quickstart/blob/main/src/api/hotel.py`, which is the wrong repo/path for this project.
- After this change, `/openapi.json` points both hotel endpoints at `couchbase-examples/python-quickstart-fastapi/blob/main/app/routers/hotel.py` and shows the actual handler names `hotel_autocomplete` / `hotel_filter`.

<details><summary>pytest output</summary>

```text
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/elliot/.openclaw/state/tutorial-maintenance/repos/python-quickstart-fastapi
plugins: anyio-4.13.0
collected 47 items

app/tests/test_airline.py ...............                                [ 31%]
app/tests/test_airport.py ...............                                [ 63%]
app/tests/test_hotel.py ........                                         [ 80%]
app/tests/test_route.py .........                                        [100%]

============================= 47 passed in 18.76s ==============================
```
</details>

<details><summary>API walkthrough excerpt</summary>

```text
HTTP/1.1 307 Temporary Redirect
location: /docs

GET /api/v1/airport/list?country=France&limit=2
[{"airportname":"Abbeville",...},{"airportname":"Aire Sur L Adour",...}]

GET /api/v1/hotel/autocomplete?name=Seal
[{"name":"Seal View"},{"name":"Seal Rock Inn"},...]

POST /api/v1/hotel/filter?limit=2
[{"city":"Los Angeles","country":"United States","name":"The Carlyle Inn",...},{"city":"Los Angeles","country":"United States","name":"El Tres Inn",...}]

POST /api/v1/airport/airport_walkthrough_20260429_fix2
201 {"airportname":"Walkthrough Airport",...}
DELETE /api/v1/airport/airport_walkthrough_20260429_fix2
204
```
</details>

- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-04-29T20-23-30Z/verification.md`
- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-04-29T20-23-30Z/walkthrough.log`
- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-04-29T20-23-30Z/walkthrough-after-fix.log`

## Notes
- I started from current `origin/main`; existing PR #227 was left untouched.
- I also noted external tutorial-page drift (older working-directory/port details than the current repo), but that content lives outside this repository so this PR only fixes the repo-side OpenAPI link drift.
