### PR TITLE
Bump FastAPI, pydantic-settings, and pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 couchbase==4.6.2
-fastapi==0.137.2
+fastapi==0.138.2
 httpx==0.28.1
 pydantic==2.13.4
-pydantic-settings==2.14.1
-pytest==9.1.0
+pydantic-settings==2.14.2
+pytest==9.1.1
 python-dotenv==1.2.2
 uvicorn==0.49.0


### PR DESCRIPTION
## Summary
- bump `fastapi` from `0.137.2` to `0.138.2`
- bump `pydantic-settings` from `2.14.1` to `2.14.2` to clear `GHSA-4xgf-cpjx-pc3j`
- bump `pytest` from `9.1.0` to `9.1.1` and re-verify the FastAPI quickstart flow against refreshed repo-local env scaffolding

## Verification
- `uv venv --clear --seed --python /usr/bin/python3.14 .venv`
- `python -m pip install -r requirements.txt`
- `pip-audit -f json`
- `python -m pytest -q`
- `uvicorn app.main:app --host 127.0.0.1 --port 8000`
- exercised `/docs`, `/openapi.json`, `GET /api/v1/airport/list?country=France&limit=2`, `GET /api/v1/hotel/autocomplete?name=Seal`, `POST /api/v1/hotel/filter?limit=2`, and airport CRUD on `airport_walkthrough_20260630`

## Evidence
- Final branch state passed `python -m pytest -q`: **47 passed, 9 warnings**.
- Final branch state passed `pip-audit -f json` with **no known vulnerabilities**.
- Live walkthrough succeeded for airport list, hotel autocomplete/filter, and airport create/read/update/delete against the running app.
- README, tutorial URL, env example, and the live FastAPI flow still line up; I left the existing Dockerfile/README Python 3.9+ support boundary unchanged in this dependency-focused pass.

<details><summary>pytest excerpt</summary>

```text
47 passed, 9 warnings in 35.79s
```

</details>

<details><summary>API walkthrough excerpt</summary>

```text
# Root
307 /docs

# OpenAPI
{
  "title": "Python Quickstart using FastAPI",
  "version": "1.0.0",
  "paths_checked": [
    "/api/v1/airport/list",
    "/api/v1/hotel/autocomplete",
    "/api/v1/hotel/filter"
  ]
}

# Airport CRUD delete
204
```

</details>

- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-06-30T15-04-42Z/verification.md`
- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-06-30T15-04-42Z/walkthrough-after-update.log`
- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-06-30T15-04-42Z/swagger-docs-after-update.png`
- `tutorial-maintenance/runs/python-quickstart-fastapi/2026-06-30T15-04-42Z/swagger-docs-after-update.webm`

## Notes
- `python -m pip list --outdated --format=json` still reports transitive `pydantic_core 2.47.0`; I left that drift alone because it is not directly pinned here.
- Baseline `pip-audit` flagged `GHSA-4xgf-cpjx-pc3j` against `pydantic-settings 2.14.1`; the final branch state clears that advisory.
- Dockerfile / README Python-version drift remains unchanged in this pass to keep the branch focused on safe dependency updates.

## Media evidence
- Auto-attached reviewer-facing media from the local verification artifacts captured during this run.
- This keeps the main PR body self-contained instead of relying on a follow-up comment for visual proof.

![Swagger Docs After Update](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1782832442/pr-evidence/couchbase-examples/python-quickstart-fastapi/pr-247/swagger-docs-after-update.png)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/python-quickstart-fastapi/2026-06-30T15-04-42Z/swagger-docs-after-update.png`

</details>

[Swagger Docs After Update](https://res.cloudinary.com/dhwqj0ps2/video/upload/v1782832444/pr-evidence/couchbase-examples/python-quickstart-fastapi/pr-247/swagger-docs-after-update.webm)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/python-quickstart-fastapi/2026-06-30T15-04-42Z/swagger-docs-after-update.webm`

</details>
